### PR TITLE
Fix composer.json aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,10 @@
             "providers": [
                 "Elielelie\\Sap\\SapServiceProvider"
             ],
-            "aliases": [
-                {
-                    "alias": "Sap",
-                    "facade": "Elielelie\\Sap\\Facades\\Sap"
-                }
-            ]
+            "aliases": {
+                "alias": "Sap",
+                "facade": "Elielelie\\Sap\\Facades\\Sap"
+            }
         }
     }
 }


### PR DESCRIPTION
Hi ,
in my bootstrap/providers.php i see that the facade is loades as array of array, tha's couse problem when i try to run test on pararell 
  
After some debug i figured out that the problem is the "aliases" keyword that shouldn't be array of object, 
just an object as write in the documentation 

[https://laravel.com/docs/11.x/packages#package-discovery]( https://laravel.com/docs/11.x/packages#package-discovery)
